### PR TITLE
Adds a menu title to make menu items accessible

### DIFF
--- a/pixel-perfecter.sketchplugin/Contents/Sketch/manifest.json
+++ b/pixel-perfecter.sketchplugin/Contents/Sketch/manifest.json
@@ -28,6 +28,7 @@
     }
   ],
   "menu": {
+    "title": "Pixel Perfecter",
     "items": [
       "all",
       "one",


### PR DESCRIPTION
Hi,

Here's a PR for an issue I just ran into; Pixel Perfecter is only available via keyboard shortcuts and is not visible in the `Plugins` menu because it is missing a `title` in `manifest.json`. 

It's worth noting that this is especially an issue for users of Anima, a popular Sketch plugin which uses the same <kbd>opt</kbd>-<kbd>cmd</kbd>-<kbd>p</kbd> shortcuts. 